### PR TITLE
topic ID is optional

### DIFF
--- a/topic.go
+++ b/topic.go
@@ -112,13 +112,13 @@ func (info *connInfo) receive() (*MessageIn, error) {
 	if err != nil {
 		return nil, err
 	}
-        if len(frame) < WaddellHeaderLength {
-                return &MessageIn{
-                      From:  peer,
-                      topic: UnknownTopic,
-                      Body:  nil,
-                }, nil 
-        }
+	if len(frame) < WaddellHeaderLength {
+		return &MessageIn{
+			From:  peer,
+			topic: UnknownTopic,
+			Body:  nil,
+		}, nil
+	}
 	topic, err := readTopicId(frame[PeerIdLength:])
 	return &MessageIn{
 		From:  peer,

--- a/topic.go
+++ b/topic.go
@@ -105,13 +105,20 @@ func (info *connInfo) receive() (*MessageIn, error) {
 	if err != nil {
 		return nil, err
 	}
-	if len(frame) < WaddellHeaderLength {
-		return nil, fmt.Errorf("Frame not long enough to contain waddell headers. Needed %d bytes, found only %d.", WaddellHeaderLength, len(frame))
+	if len(frame) < PeerIdLength {
+		return nil, fmt.Errorf("Frame not long enough to contain waddell headers. Needed %d bytes, found only %d.", PeerIdLength, len(frame))
 	}
 	peer, err := readPeerId(frame)
 	if err != nil {
 		return nil, err
 	}
+        if len(frame) < WaddellHeaderLength {
+                return &MessageIn{
+                      From:  peer,
+                      topic: UnknownTopic,
+                      Body:  nil,
+                }, nil 
+        }
 	topic, err := readTopicId(frame[PeerIdLength:])
 	return &MessageIn{
 		From:  peer,


### PR DESCRIPTION
go-natty demo program receive message from public waddell server without topic id (i.e only 16 bytes uuid assigned by server)
